### PR TITLE
Add H2H league standings support

### DIFF
--- a/endpoints/leagues.go
+++ b/endpoints/leagues.go
@@ -82,6 +82,43 @@ func (ls *LeagueService) GetClassicLeagueStandings(id, page int) (*models.Classi
 	return &league, nil
 }
 
+// GetH2HLeagueStandings returns the standings and match data for a head-to-head league by ID.
+func (ls *LeagueService) GetH2HLeagueStandings(id int) (*models.H2HLeague, error) {
+	if id <= 0 {
+		return nil, fmt.Errorf("league ID must be positive")
+	}
+
+	endpoint := fmt.Sprintf(h2hLeagueEndpoint, id)
+	resp, err := ls.client.Get(endpoint)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get h2h league standings: %w", err)
+	}
+	defer resp.Body.Close()
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+	case http.StatusNotFound:
+		return nil, fmt.Errorf("h2h league with ID %d not found", id)
+	default:
+		return nil, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	var league models.H2HLeague
+	if err := json.Unmarshal(body, &league); err != nil {
+		return nil, fmt.Errorf("failed to decode h2h league data: %w", err)
+	}
+	if league.League.ID == 0 {
+		return nil, fmt.Errorf("invalid h2h league ID")
+	}
+
+	return &league, nil
+}
+
 func (ls *LeagueService) validateLeague(league *models.ClassicLeague) error {
 	if league == nil {
 		return fmt.Errorf("received nil league data")

--- a/endpoints/leagues_test.go
+++ b/endpoints/leagues_test.go
@@ -1,6 +1,9 @@
 package endpoints_test
 
 import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/AbdoAnss/go-fantasy-pl/client"
@@ -49,4 +52,92 @@ func TestLeagueEndpoints(t *testing.T) {
 
 		assert.Equal(t, league1.GetLeagueInfo(), league2.GetLeagueInfo())
 	})
+}
+
+func TestGetH2HLeagueStandings(t *testing.T) {
+	testLeagueClient, server := newLeagueTestClient(t)
+	defer server.Close()
+
+	league, err := testLeagueClient.Leagues.GetH2HLeagueStandings(42)
+	require.NoError(t, err)
+	require.NotNil(t, league)
+
+	assert.Equal(t, 42, league.League.ID)
+	assert.Equal(t, "Test H2H League", league.League.Name)
+	require.Len(t, league.Standings.Results, 1)
+	assert.Equal(t, "North Stand FC", league.Standings.Results[0].EntryName)
+	assert.Equal(t, 7, league.Standings.Results[0].PointsTotal)
+	require.Len(t, league.MatchesNext.Results, 1)
+	assert.Equal(t, 9001, league.MatchesNext.Results[0].Entry1Entry)
+	require.NotNil(t, league.MatchesNext.Results[0].Winner)
+	assert.Equal(t, 9001, *league.MatchesNext.Results[0].Winner)
+}
+
+func TestGetH2HLeagueStandingsRejectsInvalidLeagueID(t *testing.T) {
+	testLeagueClient, server := newLeagueTestClient(t)
+	defer server.Close()
+
+	league, err := testLeagueClient.Leagues.GetH2HLeagueStandings(0)
+	require.Error(t, err)
+	assert.Nil(t, league)
+	assert.Contains(t, err.Error(), "league ID must be positive")
+}
+
+func TestGetH2HLeagueStandingsNotFound(t *testing.T) {
+	testLeagueClient, server := newLeagueTestClient(t)
+	defer server.Close()
+
+	league, err := testLeagueClient.Leagues.GetH2HLeagueStandings(404)
+	require.Error(t, err)
+	assert.Nil(t, league)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+func TestGetH2HLeagueStandingsMalformedJSON(t *testing.T) {
+	testLeagueClient, server := newLeagueTestClient(t)
+	defer server.Close()
+
+	league, err := testLeagueClient.Leagues.GetH2HLeagueStandings(500)
+	require.Error(t, err)
+	assert.Nil(t, league)
+	assert.Contains(t, err.Error(), "failed to decode h2h league data")
+}
+
+func TestGetH2HLeagueStandingsUnexpectedStatus(t *testing.T) {
+	testLeagueClient, server := newLeagueTestClient(t)
+	defer server.Close()
+
+	league, err := testLeagueClient.Leagues.GetH2HLeagueStandings(503)
+	require.Error(t, err)
+	assert.Nil(t, league)
+	assert.Contains(t, err.Error(), "unexpected status code: 503")
+}
+
+func newLeagueTestClient(t *testing.T) (*client.Client, *httptest.Server) {
+	t.Helper()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/leagues-h2h-matches/league/42/":
+			writeTestdata(t, w, "h2h-league.json")
+		case "/leagues-h2h-matches/league/500/":
+			_, err := fmt.Fprint(w, `{"league":`)
+			require.NoError(t, err)
+		case "/leagues-h2h-matches/league/503/":
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_, err := fmt.Fprint(w, `{"detail":"service unavailable"}`)
+			require.NoError(t, err)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+
+	c, err := client.NewClient(
+		client.WithBaseURL(server.URL),
+		client.WithMemoryCache(),
+	)
+	require.NoError(t, err)
+
+	return c, server
 }

--- a/endpoints/testdata/h2h-league.json
+++ b/endpoints/testdata/h2h-league.json
@@ -1,0 +1,74 @@
+{
+  "new_entries": {
+    "has_next": false,
+    "number": 1,
+    "results": []
+  },
+  "league": {
+    "id": 42,
+    "name": "Test H2H League",
+    "created": "2024-08-01T12:00:00Z",
+    "closed": false,
+    "league_type": "x",
+    "_scoring": "h",
+    "admin_entry": null,
+    "start_event": 1
+  },
+  "standings": {
+    "has_next": false,
+    "number": 1,
+    "results": [
+      {
+        "id": 1001,
+        "entry_name": "North Stand FC",
+        "player_name": "Ada Lovelace",
+        "movement": "same",
+        "own_entry": false,
+        "rank": 1,
+        "last_rank": 2,
+        "rank_sort": 1,
+        "total": 0,
+        "matches_played": 3,
+        "matches_won": 2,
+        "matches_drawn": 1,
+        "matches_lost": 0,
+        "points_for": 180,
+        "points_against": 150,
+        "points_total": 7,
+        "division": 10,
+        "entry": 9001
+      }
+    ]
+  },
+  "matches_next": {
+    "has_next": false,
+    "number": 1,
+    "results": [
+      {
+        "id": 2001,
+        "entry_1_entry": 9001,
+        "entry_1_name": "North Stand FC",
+        "entry_1_player_name": "Ada Lovelace",
+        "entry_2_entry": 9002,
+        "entry_2_name": "South Stand FC",
+        "entry_2_player_name": "Grace Hopper",
+        "is_knockout": false,
+        "winner": 9001,
+        "tiebreak": null,
+        "own_entry": false,
+        "entry_1_points": 63,
+        "entry_1_win": 1,
+        "entry_1_draw": 0,
+        "entry_1_loss": 0,
+        "entry_2_points": 58,
+        "entry_2_win": 0,
+        "entry_2_draw": 0,
+        "entry_2_loss": 1,
+        "entry_1_total": 3,
+        "entry_2_total": 0,
+        "seed_value": null,
+        "event": 1
+      }
+    ]
+  }
+}

--- a/models/league.go
+++ b/models/league.go
@@ -12,10 +12,26 @@ type ClassicLeague struct {
 	Standings       Standings  `json:"standings"`
 }
 
+// H2HLeague represents head-to-head league standings and match results.
+type H2HLeague struct {
+	NewEntries  H2HNewEntries `json:"new_entries"`
+	League      H2HLeagueInfo `json:"league"`
+	Standings   H2HStandings  `json:"standings"`
+	MatchesNext H2HMatches    `json:"matches_next"`
+}
+
 type NewEntries struct {
 	HasNext bool          `json:"has_next"`
 	Page    int           `json:"page"`
 	Results []interface{} `json:"results"` // Assuming results can be of various types
+}
+
+// H2HNewEntries represents newly joined entries for a head-to-head league.
+type H2HNewEntries struct {
+	HasNext bool          `json:"has_next"`
+	Page    int           `json:"page"`
+	Number  int           `json:"number"`
+	Results []interface{} `json:"results"`
 }
 
 // League represents the league details.
@@ -35,11 +51,36 @@ type League struct {
 	Rank        *int      `json:"rank"` // Pointer to allow null
 }
 
+// H2HLeagueInfo represents the league details returned by the H2H endpoint.
+type H2HLeagueInfo struct {
+	ID         int       `json:"id"`
+	Name       string    `json:"name"`
+	Created    time.Time `json:"created"`
+	Closed     bool      `json:"closed"`
+	LeagueType string    `json:"league_type"`
+	Scoring    string    `json:"_scoring"`
+	AdminEntry *int      `json:"admin_entry"`
+	StartEvent int       `json:"start_event"`
+	HasStarted bool      `json:"has_started"`
+	ShortName  *string   `json:"short_name"`
+	Rank       *int      `json:"rank"`
+	Size       *int      `json:"size"`
+	KoRounds   int       `json:"ko_rounds"`
+}
+
 // Standings represents the standings section of the Classic League.
 type Standings struct {
 	HasNext bool            `json:"has_next"`
 	Page    int             `json:"page"`
 	Results []LeagueManager `json:"results"`
+}
+
+// H2HStandings represents the standings section of a head-to-head league.
+type H2HStandings struct {
+	HasNext bool             `json:"has_next"`
+	Page    int              `json:"page"`
+	Number  int              `json:"number"`
+	Results []H2HLeagueEntry `json:"results"`
 }
 
 // Player represents an individual player's standings information.
@@ -54,6 +95,63 @@ type LeagueManager struct {
 	Entry      int    `json:"entry"`
 	EntryName  string `json:"entry_name"`
 	HasPlayed  bool   `json:"has_played"`
+}
+
+// H2HLeagueEntry represents an individual manager's H2H standings row.
+type H2HLeagueEntry struct {
+	ID            int    `json:"id"`
+	EntryName     string `json:"entry_name"`
+	PlayerName    string `json:"player_name"`
+	Movement      string `json:"movement"`
+	OwnEntry      bool   `json:"own_entry"`
+	Rank          int    `json:"rank"`
+	LastRank      int    `json:"last_rank"`
+	RankSort      int    `json:"rank_sort"`
+	Total         int    `json:"total"`
+	MatchesPlayed int    `json:"matches_played"`
+	MatchesWon    int    `json:"matches_won"`
+	MatchesDrawn  int    `json:"matches_drawn"`
+	MatchesLost   int    `json:"matches_lost"`
+	PointsFor     int    `json:"points_for"`
+	PointsAgainst int    `json:"points_against"`
+	PointsTotal   int    `json:"points_total"`
+	Division      int    `json:"division"`
+	Entry         int    `json:"entry"`
+}
+
+// H2HMatches represents the current or next H2H match page.
+type H2HMatches struct {
+	HasNext bool              `json:"has_next"`
+	Page    int               `json:"page"`
+	Number  int               `json:"number"`
+	Results []H2HLeagueResult `json:"results"`
+}
+
+// H2HLeagueResult represents one head-to-head match result.
+type H2HLeagueResult struct {
+	ID               int         `json:"id"`
+	Entry1Entry      int         `json:"entry_1_entry"`
+	Entry1Name       string      `json:"entry_1_name"`
+	Entry1PlayerName string      `json:"entry_1_player_name"`
+	Entry2Entry      int         `json:"entry_2_entry"`
+	Entry2Name       string      `json:"entry_2_name"`
+	Entry2PlayerName string      `json:"entry_2_player_name"`
+	IsKnockout       bool        `json:"is_knockout"`
+	Winner           *int        `json:"winner"`
+	Tiebreak         interface{} `json:"tiebreak"`
+	OwnEntry         bool        `json:"own_entry"`
+	Entry1Points     int         `json:"entry_1_points"`
+	Entry1Win        int         `json:"entry_1_win"`
+	Entry1Draw       int         `json:"entry_1_draw"`
+	Entry1Loss       int         `json:"entry_1_loss"`
+	Entry2Points     int         `json:"entry_2_points"`
+	Entry2Win        int         `json:"entry_2_win"`
+	Entry2Draw       int         `json:"entry_2_draw"`
+	Entry2Loss       int         `json:"entry_2_loss"`
+	Entry1Total      int         `json:"entry_1_total"`
+	Entry2Total      int         `json:"entry_2_total"`
+	SeedValue        interface{} `json:"seed_value"`
+	Event            int         `json:"event"`
 }
 
 func (cl *ClassicLeague) GetLeagueInfo() string {


### PR DESCRIPTION
## Summary

- Add H2H league standings models
- Add LeagueService.GetH2HLeagueStandings
- Cover success, invalid ID, not found, malformed JSON, and unexpected status cases

Fixes AbdoAnss/go-fantasy-pl#20

## Testing

- go test ./...
